### PR TITLE
Fix runtime error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
   "pytest-xdist",
   "pytest-html",
   "pytest-cov",
+  "pythonnet",
   "mypy",
   "ruff",
   "GitPython",

--- a/src/PlatynUI/ui/runtime/dotnet_interface.py
+++ b/src/PlatynUI/ui/runtime/dotnet_interface.py
@@ -66,7 +66,7 @@ class DotNetInterface:
             clr.AddReference(str(debug_assembly_path)[:-4])
         elif runtime_assembly_path.exists():
             logger.debug(f"Loading PlatynUI from {runtime_assembly_path}")  # noqa: G004
-            clr.AddReference(str(debug_assembly_path)[:-4])
+            clr.AddReference(str(runtime_assembly_path)[:-4])
         else:
             logger.error(
                 "Load PlatynUI failed: Could not find the assembly "


### PR DESCRIPTION
# Description

This PR fixes the error where the runtime is not detected, as the runtime assembly path wrongly references to the debug assembly path.
Furthermore pythonnet is added to the list of dependencies as it is required for executing PlatynUI.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Opened KCalc on Fedora Linux 42 and wrote a test case with PlatynUI.

```robotframework
*** Settings ***
Library    PlatynUI


*** Test Cases ***
KCalc - Menu Bar Quit Application
    Mouse Move To    app:Application[@Name="kcalc"]//MenuBar/MenuItem[@Name="Datei"]
    Mouse Click    app:Application[@Name="kcalc"]//MenuBar/MenuItem[@Name="Datei"]
    Mouse Move To    app:Application[@Name="kcalc"]//MenuBar/MenuItem[@Name="Datei"]/MenuItem[@Name="Beenden"]
    Mouse Click    app:Application[@Name="kcalc"]//MenuBar/MenuItem[@Name="Datei"]/MenuItem[@Name="Beenden"]
```

The test case runs after launching the hatch environment with pythonnet added and the runtime fixed.

**Test Configuration**:

- Hardware: Apple MacBook Pro M3
- OS: Linux Fedora 42 (virtualized through UTM)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.´
- [x] My changes generate no new warnings.

## Additional Notes
