### PR TITLE
Fix pipeline tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
   "pytest-xdist",
   "pytest-html",
   "pytest-cov",
+  "pythonnet",
   "mypy",
   "ruff",
   "GitPython",

--- a/src/PlatynUI/ui/runtime/dotnet_interface.py
+++ b/src/PlatynUI/ui/runtime/dotnet_interface.py
@@ -66,7 +66,7 @@ class DotNetInterface:
             clr.AddReference(str(debug_assembly_path)[:-4])
         elif runtime_assembly_path.exists():
             logger.debug(f"Loading PlatynUI from {runtime_assembly_path}")  # noqa: G004
-            clr.AddReference(str(debug_assembly_path)[:-4])
+            clr.AddReference(str(runtime_assembly_path)[:-4])
         else:
             logger.error(
                 "Load PlatynUI failed: Could not find the assembly "

--- a/tests/robot/mouse.robot
+++ b/tests/robot/mouse.robot
@@ -1,6 +1,8 @@
 *** Settings ***
 Library     PlatynUI
 
+Test Tags    wip
+
 *** Variables ***
 &{CALCULATOR}
 ...   button_1=app:Application[@Name='__main__.py']//PushButton[@Name='1']


### PR DESCRIPTION
# Description

Tests which are currently not able to run in CI/CD pipeline, e.g. because there is not remote SUT available need to be tagged with 'wip' in order to be excluded in the pipeline.
There was one test suite which is missing the 'wip' tags and causes the pipeline to fail.
This PR excludes the test suite.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added the test tags and ran the suite through the hatch config, that the pipeline uses.


## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Additional Notes
