### PR TITLE
Invalidate root node in platyn UI.extension.provider.client

### DIFF
--- a/src/PlatynUI.Runtime/Finder.cs
+++ b/src/PlatynUI.Runtime/Finder.cs
@@ -30,6 +30,21 @@ public static class Finder
         return node?.UnderlyingObject;
     }
 
+    public static void InvalidateNode(string xpath, bool findVirtual = false)
+    {
+        var parent = Desktop.GetInstance();
+
+        var navigator = new XPathNavigator(parent, findVirtual, xsltContext.NameTable);
+        var expression = XPathExpression.Compile(xpath, xsltContext);
+
+        var node = navigator.SelectSingleNode(expression);
+
+        if (node?.UnderlyingObject is INode element)
+        {
+            element.Invalidate();
+        }
+    }
+
     public static IEnumerable<object?> EnumAllNodes(INode? parent, string xpath, bool findVirtual = false)
     {
         parent ??= Desktop.GetInstance();

--- a/src/PlatynUI/__init__.py
+++ b/src/PlatynUI/__init__.py
@@ -16,6 +16,7 @@ from .keywords import (
     ElementDescriptor,
     Keyboard,
     Mouse,
+    NodeKeywords,
     Properties,
     RootElementDescriptor,
     TextKeywords,
@@ -107,7 +108,7 @@ def _add_assertion_parameters(sig: inspect.Signature) -> inspect.Signature:
 class PlatynUI(DynamicCore):
     def __init__(self) -> None:
         super().__init__(
-            [Application(), ActivatableKeywords(), TextKeywords(), Keyboard(), Mouse(), Properties(), Wait()]
+            [Application(), ActivatableKeywords(), TextKeywords(), Keyboard(), Mouse(), NodeKeywords(), Properties(), Wait()]
         )
 
     def get_keyword_arguments(self, name: str) -> Any:

--- a/src/PlatynUI/keywords/__init__.py
+++ b/src/PlatynUI/keywords/__init__.py
@@ -6,6 +6,7 @@ from .activatable import ActivatableKeywords
 from .application import Application
 from .keyboard import Keyboard
 from .mouse import Mouse
+from .node import NodeKeywords
 from .properties import Properties
 from .text import TextKeywords
 from .types import ElementDescriptor, RootElementDescriptor
@@ -17,6 +18,7 @@ __all__ = [
     "ElementDescriptor",
     "Keyboard",
     "Mouse",
+    "NodeKeywords",
     "Properties",
     "RootElementDescriptor",
     "TextKeywords",

--- a/src/PlatynUI/keywords/node.py
+++ b/src/PlatynUI/keywords/node.py
@@ -1,0 +1,13 @@
+from robotlibcore import keyword
+
+from ..ui.runtime.dotnet_interface import DotNetInterface
+
+__all__ = ["NodeKeywords"]
+
+
+class NodeKeywords:
+
+    @keyword
+    def invalidate_node(self, xpath: str) -> None:
+        """Invalidates the cached node information, so that the next access fetches fresh data."""
+        DotNetInterface.finder().InvalidateNode(xpath, False)

--- a/tests/apps/AvaloniaTestApp/ViewModels/MainWindowViewModel.cs
+++ b/tests/apps/AvaloniaTestApp/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Reactive.Linq;
+using System.Windows.Input;
 using ReactiveUI;
+using Avalonia.Controls;
 
 namespace AvaloniaTestApp.ViewModels;
 
@@ -17,10 +20,59 @@ public class MainWindowViewModel : ViewModelBase
         }
     }
 
-    readonly string[] gretings = ["Hello", "Hi", "What's up?", "How are you?"];
+    private bool _isDynamicButtonVisible = false;
+    public bool IsDynamicButtonVisible
+    {
+        get => _isDynamicButtonVisible;
+        set 
+        { 
+            this.RaiseAndSetIfChanged(ref _isDynamicButtonVisible, value);
+            this.RaisePropertyChanged(nameof(DynamicRemoveButton));
+        }
+    }
+
+    public Button? DynamicRemoveButton
+    {
+        get
+        {
+            if (!_isDynamicButtonVisible)
+                return null;
+
+            return new Button
+            {
+                Content = "Remove Me!",
+                Command = RemoveButtonCommand,
+                Margin = new Avalonia.Thickness(5, 0),
+                [Avalonia.Automation.AutomationProperties.AutomationIdProperty] = "DynamicRemoveButton"
+            };
+        }
+    }
+
+    readonly string[] greetings = ["Hello", "Hi", "What's up?", "How are you?"];
     readonly Random random = new();
+
+    public ICommand AddButtonCommand { get; }
+    public ICommand RemoveButtonCommand { get; }
+
+    public MainWindowViewModel()
+    {
+        AddButtonCommand = ReactiveCommand.Create(OnAddButton, 
+            this.WhenAnyValue(x => x.IsDynamicButtonVisible).Select(visible => !visible));
+        RemoveButtonCommand = ReactiveCommand.Create(OnRemoveButton);
+    }
+
     public void ClickCommand()
     {        
-        Greeting = gretings[random.Next(gretings.Length-1)];
+        Greeting = greetings[random.Next(greetings.Length)];
+    }
+
+    public void OnAddButton()
+    {
+        IsDynamicButtonVisible = true;
+    }
+
+    public void OnRemoveButton()
+    {
+        IsDynamicButtonVisible = false;
     }
 }

--- a/tests/apps/AvaloniaTestApp/Views/MainWindow.axaml
+++ b/tests/apps/AvaloniaTestApp/Views/MainWindow.axaml
@@ -8,8 +8,8 @@
     x:DataType="vm:MainWindowViewModel"
     Icon="/Assets/avalonia-logo.ico"
     Title="AvaloniaTestApp"
-    Width="300"
-    Height="200"
+    Width="600"
+    Height="500"
     x:Name="Main">
 
 
@@ -19,15 +19,33 @@
         App.axaml.cs) -->
         <vm:MainWindowViewModel />
     </Design.DataContext>
-    <StackPanel>
-        <TextBlock Text="Hello, World!" HorizontalAlignment="Center" VerticalAlignment="Center" AutomationProperties.AutomationId="Hallo World"/>
-        <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center" />
-        <Button Content="Click me!" Command="{Binding ClickCommand}" HorizontalAlignment="Center"
-            VerticalAlignment="Center" />
-        <TextBox x:Name="AutoCompleteEditBox" Text="{Binding Greeting}"
-            HorizontalAlignment="Center" VerticalAlignment="Center" AutomationProperties.AutomationId="ATextBox" />
-        <ScrollBar AutomationProperties.AutomationId="MyScrollBar" Name="MyScrollBar"
-             HorizontalAlignment="Left" Visibility="Visible" VerticalAlignment="Center" Orientation="Horizontal" Width="100" />                
-    </StackPanel>
+    
+    <ScrollViewer>
+        <StackPanel Margin="10">
+            <!-- Original Content -->
+            <TextBlock Text="Hello, World!" HorizontalAlignment="Center" VerticalAlignment="Center" AutomationProperties.AutomationId="Hallo World"/>
+            <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            <Button Content="Click me!" Command="{Binding ClickCommand}" HorizontalAlignment="Center"
+                VerticalAlignment="Center" />
+            <TextBox x:Name="AutoCompleteEditBox" Text="{Binding Greeting}"
+                HorizontalAlignment="Center" VerticalAlignment="Center" AutomationProperties.AutomationId="ATextBox" />
+            <ScrollBar AutomationProperties.AutomationId="MyScrollBar" Name="MyScrollBar"
+                 HorizontalAlignment="Left" Visibility="Visible" VerticalAlignment="Center" Orientation="Horizontal" Width="100" />
+            
+            <!-- Separator -->
+            <Separator Margin="0,20,0,20" />
+            
+            <!-- Dynamic Content Controls -->
+            <TextBlock Text="Dynamic Button Generator" FontSize="16" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,10"/>
+            
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10" Margin="0,0,0,20">
+                <Button Content="Add Button" Command="{Binding AddButtonCommand}" 
+                        AutomationProperties.AutomationId="AddButtonCommand" />
+                
+                <!-- Dynamic Button - only exists in visual tree when visible -->
+                <ContentControl Content="{Binding DynamicRemoveButton}" />
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
 
 </Window>

--- a/tests/robot/playground/dynamic_content.robot
+++ b/tests/robot/playground/dynamic_content.robot
@@ -1,0 +1,10 @@
+*** Settings ***
+Library     PlatynUI
+
+
+*** Test Cases ***
+
+Check Dynamic Content
+    Mouse Click    app:Application[@Name="AvaloniaTestApp"]/MainWindow//Button[@AutomationId='AddButtonCommand']
+    Sleep    1s
+    Mouse Click    app:Application[@Name="AvaloniaTestApp"]/MainWindow//Button[@AutomationId='DynamicRemoveButton']


### PR DESCRIPTION
# Description

When the content of the Avalonia UI is changed dynamically (for example, a popup window appears), the affected node's Children list is not updated in the PlatynUI.Extension.Provider.Client. This means that the new nodes cannot be found by FindSingleNode.

This modification contains a new keyword that calls the Invalidate() function of the node specified by the xpath expression.

Other extra fixes in this PR:
- doubleclick time is fixed (it was retrieved as milliseconds, but should be handled as seconds)
- type keys without context keyword is added

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

A dynamic button generation feature is added to the AvaloniaTestApp. Use the tests/robot/playground/dynamic_content.robot
test to try this out.

**Test Configuration**:

- Firmware version: -
- Hardware: -
- OS: Debian 12
- Browser (if applicable): -

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Additional Notes
