### PR TITLE
convert doubleclicktime to seconds

### DIFF
--- a/src/PlatynUI/technology/uiautomation/core/mousedevice.py
+++ b/src/PlatynUI/technology/uiautomation/core/mousedevice.py
@@ -12,7 +12,7 @@ from .loader import DotNetInterface
 class UiaMouseDevice(BaseMouseDevice):
     @property
     def double_click_time(self) -> float:
-        return DotNetInterface.mouse_device().GetDoubleClickTime()
+        return DotNetInterface.mouse_device().GetDoubleClickTime() * 0.001  # ms to s
 
     @property
     def double_click_size(self) -> Size:

--- a/src/PlatynUI/ui/runtime/mouse_device_impl.py
+++ b/src/PlatynUI/ui/runtime/mouse_device_impl.py
@@ -12,7 +12,7 @@ from .dotnet_interface import DotNetInterface
 class MouseDeviceImpl(BaseMouseDevice):
     @property
     def double_click_time(self) -> float:
-        return DotNetInterface.mouse_device().GetDoubleClickTime()
+        return DotNetInterface.mouse_device().GetDoubleClickTime() * 0.001  # ms to s
 
     @property
     def double_click_size(self) -> Size:


### PR DESCRIPTION
# Description

mouse_device().GetDoubleClickTime() retrieves milliseconds, but InputDevice.delay() takes seconds as argument, which results in 10 times higher delay in double click (or clicking the same button twice)

Fixes # (issue)

doubleclick time is fixed (it was retrieved as milliseconds, but should be handled as seconds)

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Click the same button twice.

**Test Configuration**:

- Firmware version:
- Hardware:
- OS:
- Browser (if applicable):

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Additional Notes
