### PR TITLE
Fix desktop invalidate funciton

### DIFF
--- a/src/PlatynUI.Runtime/Desktop.cs
+++ b/src/PlatynUI.Runtime/Desktop.cs
@@ -104,6 +104,11 @@ public class Desktop : INode, IAdapter, IElement
 
     public void Invalidate()
     {
+        foreach (var child in Children)
+        {
+            try { child.Invalidate(); } catch { }
+        }
+
         _children = null;
     }
 

--- a/tests/apps/AvaloniaTestApp/ViewModels/MainWindowViewModel.cs
+++ b/tests/apps/AvaloniaTestApp/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Reactive.Linq;
+using System.Windows.Input;
 using ReactiveUI;
+using Avalonia.Controls;
 
 namespace AvaloniaTestApp.ViewModels;
 
@@ -17,10 +20,59 @@ public class MainWindowViewModel : ViewModelBase
         }
     }
 
-    readonly string[] gretings = ["Hello", "Hi", "What's up?", "How are you?"];
+    private bool _isDynamicButtonVisible = false;
+    public bool IsDynamicButtonVisible
+    {
+        get => _isDynamicButtonVisible;
+        set 
+        { 
+            this.RaiseAndSetIfChanged(ref _isDynamicButtonVisible, value);
+            this.RaisePropertyChanged(nameof(DynamicRemoveButton));
+        }
+    }
+
+    public Button? DynamicRemoveButton
+    {
+        get
+        {
+            if (!_isDynamicButtonVisible)
+                return null;
+
+            return new Button
+            {
+                Content = "Remove Me!",
+                Command = RemoveButtonCommand,
+                Margin = new Avalonia.Thickness(5, 0),
+                [Avalonia.Automation.AutomationProperties.AutomationIdProperty] = "DynamicRemoveButton"
+            };
+        }
+    }
+
+    readonly string[] greetings = ["Hello", "Hi", "What's up?", "How are you?"];
     readonly Random random = new();
+
+    public ICommand AddButtonCommand { get; }
+    public ICommand RemoveButtonCommand { get; }
+
+    public MainWindowViewModel()
+    {
+        AddButtonCommand = ReactiveCommand.Create(OnAddButton, 
+            this.WhenAnyValue(x => x.IsDynamicButtonVisible).Select(visible => !visible));
+        RemoveButtonCommand = ReactiveCommand.Create(OnRemoveButton);
+    }
+
     public void ClickCommand()
     {        
-        Greeting = gretings[random.Next(gretings.Length-1)];
+        Greeting = greetings[random.Next(greetings.Length)];
+    }
+
+    public void OnAddButton()
+    {
+        IsDynamicButtonVisible = true;
+    }
+
+    public void OnRemoveButton()
+    {
+        IsDynamicButtonVisible = false;
     }
 }

--- a/tests/apps/AvaloniaTestApp/Views/MainWindow.axaml
+++ b/tests/apps/AvaloniaTestApp/Views/MainWindow.axaml
@@ -8,8 +8,8 @@
     x:DataType="vm:MainWindowViewModel"
     Icon="/Assets/avalonia-logo.ico"
     Title="AvaloniaTestApp"
-    Width="300"
-    Height="200"
+    Width="600"
+    Height="500"
     x:Name="Main">
 
 
@@ -19,15 +19,35 @@
         App.axaml.cs) -->
         <vm:MainWindowViewModel />
     </Design.DataContext>
-    <StackPanel>
-        <TextBlock Text="Hello, World!" HorizontalAlignment="Center" VerticalAlignment="Center" AutomationProperties.AutomationId="Hallo World"/>
-        <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center" />
-        <Button Content="Click me!" Command="{Binding ClickCommand}" HorizontalAlignment="Center"
-            VerticalAlignment="Center" />
-        <TextBox x:Name="AutoCompleteEditBox" Text="{Binding Greeting}"
-            HorizontalAlignment="Center" VerticalAlignment="Center" AutomationProperties.AutomationId="ATextBox" />
-        <ScrollBar AutomationProperties.AutomationId="MyScrollBar" Name="MyScrollBar"
-             HorizontalAlignment="Left" Visibility="Visible" VerticalAlignment="Center" Orientation="Horizontal" Width="100" />                
-    </StackPanel>
+    
+    <ScrollViewer>
+        <StackPanel Margin="10">
+            <!-- Original Content -->
+            <TextBlock Text="Hello, World!" HorizontalAlignment="Center" VerticalAlignment="Center" AutomationProperties.AutomationId="Hallo World"/>
+            <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            <Button Content="Click me!" Command="{Binding ClickCommand}" HorizontalAlignment="Center"
+                VerticalAlignment="Center" />
+            <TextBox x:Name="AutoCompleteEditBox" Text="{Binding Greeting}"
+                HorizontalAlignment="Center" VerticalAlignment="Center" AutomationProperties.AutomationId="ATextBox" />
+            <ScrollBar AutomationProperties.AutomationId="MyScrollBar" Name="MyScrollBar"
+                 HorizontalAlignment="Left" Visibility="Visible" VerticalAlignment="Center" Orientation="Horizontal" Width="100" />
+            
+            <!-- Separator -->
+            <Separator Margin="0,20,0,20" />
+            
+            <!-- Dynamic Content Controls -->
+            <TextBlock Text="Dynamic Button Generator" FontSize="16" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,10"/>
+            
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10" Margin="0,0,0,20">
+                <Button Content="Add Button" Command="{Binding AddButtonCommand}" 
+                        AutomationProperties.AutomationId="AddButtonCommand" />                
+                
+                <!-- Dynamic Button - only exists in visual tree when visible -->
+                <ContentControl Content="{Binding DynamicRemoveButton}" />
+            </StackPanel>
+            <Button Content="Dummy Button" HorizontalAlignment="Center"
+                VerticalAlignment="Center" AutomationProperties.AutomationId="DummyButton" />
+        </StackPanel>
+    </ScrollViewer>
 
 </Window>

--- a/tests/robot/playground/dynamic_content.robot
+++ b/tests/robot/playground/dynamic_content.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Library     PlatynUI
+
+
+*** Test Cases ***
+
+Check Dynamic Content
+    Mouse Click    app:Application[@Name="AvaloniaTestApp"]/MainWindow//Button[@AutomationId='AddButtonCommand']
+    Sleep    1s
+    Mouse Click    app:Application[@Name="AvaloniaTestApp"]/MainWindow//Button[@AutomationId='DynamicRemoveButton']
+
+Check Dynamic Content 2
+    Mouse Click    app:Application[@Name="AvaloniaTestApp"]/MainWindow//Button[@AutomationId='DummyButton']
+    Sleep    1s
+    Mouse Click    app:Application[@Name="AvaloniaTestApp"]/MainWindow//Button[@AutomationId='AddButtonCommand']
+    Sleep    1s
+    #Invalidate Node    app:Application[@Name="AvaloniaTestApp"]
+    Mouse Click    app:Application[@Name="AvaloniaTestApp"]/MainWindow//Button[@AutomationId='DynamicRemoveButton']


### PR DESCRIPTION
# Description

The Invalidate() method of the Desktop class only invalidates the children of the Desktop (the Applications), but the children of those are still cached, which makes the Invalidate() method ineffective.

Additional information about the behavior of the PlatynUI: The PlatynUI walks through the visualtree of the tested application to find the element that is specified by the xpath, and caches the touched nodes. If there is a match, it will look no further, and the remaining nodes will not be cached. If the children of a cached node are changed (e.g. popup window), the Provider.Client will not be updated, unless the node, or it's ancestors are invalidated.

Result of this behavior:
Dynamically created children of cached nodes can't be found because of the ineffective invalidation.

This modification fixes this issue by invalidating the grandchildren of the Desktop as well.
The PR also contains modifications for the AvaloniaTestApp to test this function.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

AvaloniaTestApp is extended and the dynamic_content.robot test is added to demonstrate the problem.
Two buttons are added: "Add Button", and "Dummy Button". The "Add button" dynamically adds an extra button to the screen with a text "Remove me!". The "Remove me!" button removes itself.

dynamic_content.robot
Test1: Check Dynamic Content:
 - it proves that a dynamically created button can be found and be clicked

Test2: Check Dynamic Content 2:
- it proves that a dynamically created button of a cached parent can be found and be clicked

**Test Configuration**:

- Firmware version:
- Hardware:
- OS: Debian 12
- Browser (if applicable):

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Additional Notes
