### PR TITLE
feat: ignore invisible nodes in avalonia

### DIFF
--- a/src/PlatynUI.Provider.Avalonia/ElementNode.cs
+++ b/src/PlatynUI.Provider.Avalonia/ElementNode.cs
@@ -193,6 +193,7 @@ internal class ElementNode : Node<Control>
         return Element
             .GetVisualChildren()
             .Cast<Control>()
+            .Where(e => e.IsEffectivelyVisible == true)
             .Select(e => NodeInfo.GetOrCreateNode<ElementNode, Control>(e))
             .Where(n => n != null && n.IsValid());
     }


### PR DESCRIPTION
# Description

In avalonia, nodes with false IsEffectivelyVisible property are also represented in the visualtree, but may make it more difficult to find the visible elements. This modification filters out these when requesting for nodes. As a result it may speed up the search.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

xpath filtering can simplified, because the IsEffectivelyVisible property should not be checked.
An improvement in the search speed can be observed when using large and complex visualtree.

**Test Configuration**:

- Firmware version:
- Hardware:
- OS: Debian 11
- Browser (if applicable):

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Additional Notes
