### PR TITLE
add keywords Get Children, Get Children Locators

### DIFF
--- a/src/PlatynUI.Extension.Win32.UiAutomation/ElementNode.cs
+++ b/src/PlatynUI.Extension.Win32.UiAutomation/ElementNode.cs
@@ -83,7 +83,7 @@ public partial class ElementNode(INode? parent, IUIAutomationElement element) : 
 
     public string FrameworkId => Element.CurrentFrameworkId;
 
-    public string RuntimeId => throw new NotImplementedException();
+    public string RuntimeId => Helper.GetRuntimeId(Element);
 
     static readonly object InvalidValue = new();
 

--- a/src/PlatynUI/__init__.py
+++ b/src/PlatynUI/__init__.py
@@ -14,6 +14,7 @@ from .keywords import (
     ActivatableKeywords,
     Application,
     ElementDescriptor,
+    Elements,
     Keyboard,
     Mouse,
     Properties,
@@ -107,7 +108,7 @@ def _add_assertion_parameters(sig: inspect.Signature) -> inspect.Signature:
 class PlatynUI(DynamicCore):
     def __init__(self) -> None:
         super().__init__(
-            [Application(), ActivatableKeywords(), TextKeywords(), Keyboard(), Mouse(), Properties(), Wait()]
+            [Application(), ActivatableKeywords(), TextKeywords(), Keyboard(), Mouse(), Properties(), Wait(), Elements()]
         )
 
     def get_keyword_arguments(self, name: str) -> Any:

--- a/src/PlatynUI/keywords/__init__.py
+++ b/src/PlatynUI/keywords/__init__.py
@@ -4,6 +4,7 @@
 
 from .activatable import ActivatableKeywords
 from .application import Application
+from .elements import Elements
 from .keyboard import Keyboard
 from .mouse import Mouse
 from .properties import Properties
@@ -15,6 +16,7 @@ __all__ = [
     "ActivatableKeywords",
     "Application",
     "ElementDescriptor",
+    "Elements",
     "Keyboard",
     "Mouse",
     "Properties",

--- a/src/PlatynUI/keywords/elements.py
+++ b/src/PlatynUI/keywords/elements.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2024 Daniel Biehl <daniel.biehl@imbus.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from robotlibcore import keyword
+
+from ..core.contextbase import ContextBase
+from .types import ElementDescriptor
+
+
+class Elements:
+    @keyword
+    def get_children(self, descriptor: ElementDescriptor) -> List[ContextBase]:
+        return descriptor.context().get_children(None)

--- a/src/PlatynUI/keywords/elements.py
+++ b/src/PlatynUI/keywords/elements.py
@@ -14,3 +14,29 @@ class Elements:
     @keyword
     def get_children(self, descriptor: ElementDescriptor) -> List[ContextBase]:
         return descriptor.context().get_children(None)
+
+    @keyword
+    def get_children_locators(self, descriptor: ElementDescriptor) -> List[str]:
+        """Return XPath locator strings for each direct child of the element."""
+        parent_context = descriptor.context()
+        parent_locator = parent_context.locator
+        parent_path = getattr(parent_locator, "path", None) or parent_locator.get_path(
+            parent_context.context_parent, context_type=type(parent_context)
+        )
+
+        result: List[str] = []
+        for child in parent_context.get_children(None):
+            adapter = child._adapter
+            if adapter is None:
+                continue
+
+            role = adapter.role or "*"
+            attr = (
+                "@AutomationId='%s'" % adapter.id if adapter.id
+                else "@Name='%s'" % adapter.name if adapter.name
+                else None
+            )
+            segment = "%s[%s]" % (role, attr) if attr else role
+            result.append("%s/%s" % (parent_path, segment) if parent_path else segment)
+
+        return result

--- a/src/PlatynUI/ui/runtime/adapterfactory_impl.py
+++ b/src/PlatynUI/ui/runtime/adapterfactory_impl.py
@@ -105,8 +105,30 @@ class AdapterFactoryImpl(AdapterFactory):
         locator: LocatorBase,
         raise_error: Optional[bool] = True,
     ) -> List["Adapter"]:
-        # TODO
-        return []
+        if not isinstance(locator, Locator):
+            if raise_error:
+                raise ValueError(f"Invalid locator type: {locator}")
+            return []
+
+        parent_adapter = parent.adapter if parent else None
+        while parent_adapter is not None and isinstance(parent_adapter, AdapterProxy):
+            parent_adapter = parent_adapter.adapter
+
+        parent_impl = (
+            parent_adapter._adapter_interface if parent_adapter and isinstance(parent_adapter, AdapterImpl) else None
+        )
+        path = locator.get_path(parent, context_type=context_type)
+
+        nodes = DotNetInterface.finder().FindNodes(cast("INode", parent_impl), path, False)
+
+        results: List["Adapter"] = []
+        for node in nodes:
+            if node is not None:
+                results.append(
+                    AdapterProxyFactory.find_proxy_for(AdapterImpl(cast("IAdapter", node), self._technology))
+                )
+
+        return results
 
     def get_parent_adapter(
         self,

--- a/tests/robot/elements.robot
+++ b/tests/robot/elements.robot
@@ -1,0 +1,89 @@
+*** Settings ***
+Library         PlatynUI
+Library         Collections
+Variables       mapping.py
+Test Setup      Check Calculator And Zehnertastatur Exist
+
+*** Test Cases ***
+Click All Calculator Digits Via Children
+    ${digit_buttons}=    Collect Digit Buttons From Children    /Window[@Name='Rechner']//Group[@Name="Zehnertastatur"]
+    Length Should Be    ${digit_buttons}    10
+
+    FOR    ${button}    IN    @{digit_buttons}
+        Activate    ${button}
+    END
+
+
+Test Get Children
+    ${children}=    Get Children    /Window[@Name='Rechner']//Group[@Name="Zehnertastatur"]
+    ${count}=    Get Length    ${children}
+    
+    Log    Found ${count} children in Zehnertastatur group    INFO
+    
+    # Log properties of first few children
+    FOR    ${idx}    ${child}    IN ENUMERATE    @{children}
+        ${aid}=    Get Property Value    ${child}    AutomationId
+        Log    Child ${idx}: AutomationId=${aid}    INFO
+        ${names}=    Get Property Names    ${child}   
+        Log    Child ${idx}: Property Names=${names}    INFO
+        ${break}=    Evaluate    ${idx} >= 4
+        IF    ${break}
+            BREAK
+        END
+    END
+    
+    # Should find at least the buttons (0-9 plus decimal point)
+    Length Should Be    ${children}    11
+
+Test Get Children Locators
+    
+    # Get Children Locators returns XPath strings
+    ${children}=    Get Children Locators    /Window[@Name='Rechner']//Group[@Name="Zehnertastatur"]
+    ${count}=    Get Length    ${children}
+    Log    Found ${count} children in Zehnertastatur group    INFO
+
+    # Log each child locator
+    FOR    ${idx}    ${child}    IN ENUMERATE    @{children}
+        Log    ${idx}: ${child}    INFO
+    END
+
+    # Should find 11 buttons (0-9 plus decimal point)
+    Length Should Be    ${children}    11
+
+    # Each locator is a usable XPath string
+    FOR    ${child}    IN    @{children}
+        ${aid}=    Get Property Value    ${child}    AutomationId
+        Log    ${child} -> AutomationId=${aid}    INFO
+    END
+
+
+*** Keywords ***
+Collect Digit Buttons From Children
+    [Arguments]    ${parent}
+
+    ${children}=    Get Children    ${parent}
+    log  LIST OF CHILDREN: ${children}
+    
+    VAR    @{digit_buttons}
+    ${child_count}=    Get Length    ${children}
+
+    # Build an ordered list num0Button..num9Button from all children.
+    FOR    ${digit}    IN RANGE    0    10
+        VAR    ${target_id}    num${digit}Button
+        FOR    ${child}    IN    @{children}
+            ${automation_id}=    Get Property Value    ${child}    AutomationId
+            IF    '${automation_id}' == '${target_id}'
+                Append To List    ${digit_buttons}    ${child}
+                BREAK
+            END
+        END
+    END
+
+    RETURN    ${digit_buttons}
+
+
+Check Calculator And Zehnertastatur Exist
+    Ensure Exists    ${calculator}    
+    Ensure Exists    /Window[@Name='Rechner']//Group[@Name="Zehnertastatur"]    
+    Activate     /Window[@Name='Rechner']//Button[@Name='Löschen']
+


### PR DESCRIPTION
Description
The Get Children keyword always returned an empty list because AdapterFactoryImpl.get_children_adapters() was a stub (# TODO return []). This change implements the method using Finder.FindNodes() to resolve all direct children via XPath, following the same pattern as the existing get_adapter() method which uses FindSingleNode() for single element lookups.

ElementNode.RuntimeId was throwing NotImplementedException, which caused a crash when creating child adapters since RuntimeId is read to build unique locators. It now delegates to Helper.GetRuntimeId() which was already available but not wired up.

Additionally, a new Get Children Locators keyword is introduced. While Get Children returns context objects, Get Children Locators returns a list of full XPath locator strings built from the parent path plus each child's role and AutomationId or Name. These strings are human-readable in test logs and can be passed directly to other keywords like Activate or Get Property Value.

Type of Change
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)

How Has This Been Tested?

 Test Click All Calculator Digits Via Children 
- Uses Get Children to find digit buttons in the calculator's Zehnertastatur group, filters by AutomationId, and activates each one.
 Test Test Get Children 
- Verifies Get Children returns 11 child elements (digits 0-9 plus decimal separator) and reads their properties.
 Test Test Get Children Locators 
- Verifies Get Children Locators returns 11 XPath strings and that each string can be used with Get Property Value to read the AutomationId.

Test Configuration:
OS: Windows 11 ARM64
Python: 3.13.13
Robot Framework: 7.4.2
.NET Runtime: CoreCLR
Test application: Windows Calculator (Rechner)

Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

Additional Notes
The C# project PlatynUI.Extension.Win32.UiAutomation must be rebuilt after pulling this change so the updated ElementNode.RuntimeId implementation is included in the DLL. Run dotnet build src/PlatynUI.Spy/PlatynUI.Spy.csproj to rebuild all dependent assemblies.